### PR TITLE
Add images attribute to keycloak kustomization file

### DIFF
--- a/katalog/keycloak/kustomization.yaml
+++ b/katalog/keycloak/kustomization.yaml
@@ -7,3 +7,7 @@ configMapGenerator:
   - name: cache-owners
     files:
     - cache-owners.cli
+
+images:
+  - name: jboss/keycloak
+    newTag: 7.0.1


### PR DESCRIPTION
Hi team!

I open this PR because I have seen we are using "latest" version of keycloak image in the deployment. This can cause problems when the upstream image is upgraded. So i suggest to fix the version in its kustomization file in order to change it in a easy way.

Thanks!