### PR TITLE
Update keycloak from 7 to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The following packages are included in the Fury Kubernetes KeyCloak Katalog.
 
 - **[keycloak](#keycloak)**: high availability KeyCloak using native Kubernetes namespace based discovery.
 This will form a KeyCloak cluster where the members will be all the KeyCloaks pods in the same Kubernetes namespace.
-Version: **7.0.1**.
+Version: **13.0.1**.
 
 ## Requirements
 
@@ -27,6 +27,7 @@ specific dependencies, please visit the single package's documentation:
 | ----------------------------------- | :----------------: | :----------------: | :----------------: | :-------: |
 | v1.0.0                              |                    |                    |                    |           |
 | v1.0.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
+| v1.1.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: | :warning: |
 
 - :white_check_mark: Compatible
 - :warning: Has issues

--- a/docs/releases/v1.1.0.md
+++ b/docs/releases/v1.1.0.md
@@ -1,0 +1,26 @@
+# KeyCloak Module version 1.1.0
+
+SIGHUP team maintains this module updated and tested.
+That is the main reason why we worked on this new release. With the Kubernetes 1.21 release, it became the perfect time
+to start testing this module against this Kubernetes release.
+
+Continue reading the Changelog to discover them:
+
+## Changelog
+
+- Update KeyCloak from version `v7.0.1` to `v13.0.1`.
+- Kubernetes support:
+  - Deprecate Kubernetes 1.17 support.
+  - Kubernetes 1.20 is considered stable.
+  - Add tech-preview support to Kubernetes 1.21.
+
+## Upgrade path
+
+To upgrade this module from `v1.0.1` to `v1.1.0`, you need to download this new version, then apply the
+`kustomize` project. No further action is required.
+
+```bash
+$ kustomize build katalog/keycloak | kubectl apply -f -
+# Or
+$ kustomize build examples/h2-tests | kubectl apply -f -
+```

--- a/katalog/keycloak/kustomization.yaml
+++ b/katalog/keycloak/kustomization.yaml
@@ -14,4 +14,4 @@ configMapGenerator:
 images:
   - name: jboss/keycloak
     newName: registry.sighup.io/fury/jboss/keycloak
-    newTag: 7.0.1
+    newTag: 13.0.1


### PR DESCRIPTION
# KeyCloak Module version 1.1.0

SIGHUP team maintains this module updated and tested.
That is the main reason why we worked on this new release. With the Kubernetes 1.21 release, it became the perfect time
to start testing this module against this Kubernetes release.

Continue reading the Changelog to discover them:

## Changelog

- Update KeyCloak from version `v7.0.1` to `v13.0.1`.
- Kubernetes support:
  - Deprecate Kubernetes 1.17 support.
  - Kubernetes 1.20 is considered stable.
  - Add tech-preview support to Kubernetes 1.21.

## Upgrade path

To upgrade this module from `v1.0.1` to `v1.1.0`, you need to download this new version, then apply the
`kustomize` project. No further action is required.

```bash
$ kustomize build katalog/keycloak | kubectl apply -f -
# Or
$ kustomize build examples/h2-tests | kubectl apply -f -
```
