### PR TITLE
feat: upgrade Keycloak Operator to v26.2.2

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -332,7 +332,7 @@ steps:
       - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
 
   - name: e2e
-    # KUBECTL 1.32.5 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    # KUBECTL 1.32.2 - KUSTOMIZE 5.6.0 - HELM 3.12.0 - YQ 4.33.3 - BATS 1.1.0 - AWSCLI 2.24.17 - TOFU 1.9.0
     image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
     pull: always
     network_mode: host

--- a/.drone.yml
+++ b/.drone.yml
@@ -57,7 +57,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.31.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.32.0
     environment:
       KUBERNETES_MANIFESTS: keycloak-operated.yml
 
@@ -65,82 +65,6 @@ steps:
     name: check-deprecated-apis-keycloak-operator
     environment:
       KUBERNETES_MANIFESTS: keycloak-operator.yml
-
----
-name: e2e-kubernetes-1.28
-kind: pipeline
-type: docker
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/heads/main
-      - refs/heads/release-v*
-      - refs/tags/**
-
-steps:
-  - name: create-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
-    pull: always
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    depends_on: [clone]
-    environment:
-      CLUSTER_VERSION: v1.28.0
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
-      # /drone/src is the default workdir for the pipeline
-      # using this folder we don't need to mount another
-      # shared volume between the steps
-      KUBECONFIG: /drone/src/kubeconfig-128
-    commands:
-      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
-      # does not work when disabling the default CNI. It will always go in timeout.
-      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config katalog/tests/kind-config.yml
-      # save the kubeconfig so we can use it from other steps.
-      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
-
-  - name: e2e
-    # KUBECTL 1.28.5 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
-    image: quay.io/sighup/e2e-testing:1.1.0_0.11.0_3.12.0_1.9.4_1.28.5_3.5.3_4.33.3
-    pull: always
-    network_mode: host
-    environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
-      KUBECONFIG: /drone/src/kubeconfig-128
-    depends_on: [create-kind-cluster]
-    commands:
-      - bats -t katalog/tests/deploy-keycloak.sh
-      - bats -t katalog/tests/test-users-keycloak.sh
-
-  - name: delete-kind-cluster
-    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.20.0_1.29.1_3.10.0
-    volumes:
-      - name: dockersock
-        path: /var/run/docker.sock
-    pull: always
-    depends_on: [e2e]
-    environment:
-      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-128
-    commands:
-      # does not matter if the command fails
-      - kind delete cluster --name $${CLUSTER_NAME} || true
-    when:
-      status:
-        - success
-        - failure
-
-volumes:
-  - name: dockersock
-    host:
-      path: /var/run/docker.sock
 ---
 name: e2e-kubernetes-1.29
 kind: pipeline
@@ -367,14 +291,89 @@ volumes:
     host:
       path: /var/run/docker.sock
 ---
+name: e2e-kubernetes-1.32
+kind: pipeline
+type: docker
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/heads/main
+      - refs/heads/release-v*
+      - refs/tags/**
+
+steps:
+  - name: create-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    pull: always
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    depends_on: [clone]
+    environment:
+      CLUSTER_VERSION: v1.32.2
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-132
+      # /drone/src is the default workdir for the pipeline
+      # using this folder we don't need to mount another
+      # shared volume between the steps
+      KUBECONFIG: /drone/src/kubeconfig-132
+    commands:
+      # NOTE: kind's `--wait` flag that waits for the control-plane ot be ready
+      # does not work when disabling the default CNI. It will always go in timeout.
+      - kind create cluster --name $${CLUSTER_NAME} --image registry.sighup.io/fury/kindest/node:$${CLUSTER_VERSION} --config katalog/tests/kind-config.yml
+      # save the kubeconfig so we can use it from other steps.
+      - kind get kubeconfig --name $${CLUSTER_NAME} > $${KUBECONFIG}
+
+  - name: e2e
+    # KUBECTL 1.32.5 - KUSTOMIZE 3.5.3 - HELM 3.1.1 - YQ 4.21.1 - ISTIOCTL 1.9.4 - FURYCTL 0.9.0 - BATS 1.1.0
+    image: quay.io/sighup/e2e-testing:2.24.17_1.1.0_3.12.0_1.32.2_5.6.0_4.33.3
+    pull: always
+    network_mode: host
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-132
+      KUBECONFIG: /drone/src/kubeconfig-132
+    depends_on: [create-kind-cluster]
+    commands:
+      - bats -t katalog/tests/deploy-keycloak.sh
+      - bats -t katalog/tests/test-users-keycloak.sh
+
+  - name: delete-kind-cluster
+    image: quay.io/sighup/dind-kind-kubectl-kustomize:0.27.0_1.32.2_5.6.0
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+    pull: always
+    depends_on: [e2e]
+    environment:
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-132
+    commands:
+      # does not matter if the command fails
+      - kind delete cluster --name $${CLUSTER_NAME} || true
+    when:
+      status:
+        - success
+        - failure
+
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+---
 kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.28
   - e2e-kubernetes-1.29
   - e2e-kubernetes-1.30
   - e2e-kubernetes-1.31
+  - e2e-kubernetes-1.32
 
 platform:
   os: linux
@@ -384,6 +383,8 @@ trigger:
   ref:
     include:
       - refs/tags/**
+    exclude: 
+      - refs/tags/e2e-**
 
 steps:
   - name: prepare-tar-gz

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   Keycloak Add-On Module
 </h1>
 
-![Release](https://img.shields.io/badge/Latest%20Release-v2.2.0-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v2.3.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/add-on-keycloak?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -33,10 +33,10 @@ Click on each package to see its full documentation.
 
 | Kubernetes Version |   Compatibility    | Notes           |
 | ------------------ | :----------------: | --------------- |
-| `1.28.x`           | :white_check_mark: | No known issues |
 | `1.29.x`           | :white_check_mark: | No known issues |
 | `1.30.x`           | :white_check_mark: | No known issues |
 | `1.31.x`           | :white_check_mark: | No known issues |
+| `1.32.x`           | :white_check_mark: | No known issues |
 
 ## Usage
 
@@ -54,9 +54,9 @@ Click on each package to see its full documentation.
 ```yaml
 bases:
   - name: keycloak/keycloak-operator
-    version: "v2.2.0"
+    version: "v2.3.0"
   - name: keycloak/keycloak-operated
-    version: "v2.2.0"
+    version: "v2.3.0"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The following packages are included in the Fury Kubernetes Keycloak katalog:
 
 | Package                                                | Version                         | Description                                                                                 |
 | ------------------------------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------- |
-| [keycloak-operator](katalog/keycloak-operator)         | `26.0.2`                        | Operator to deploy and manage Keycloak and related resources |
-| [keycloak-operated](katalog/keycloak-operated)         | `26.0.2`                        | High availability KeyCloak using native Kubernetes namespace based discovery. This will form a KeyCloak cluster where the members will be all the KeyCloaks pods in the same Kubernetes namespace.                         |
+| [keycloak-operator](katalog/keycloak-operator)         | `26.2.2`                        | Operator to deploy and manage Keycloak and related resources |
+| [keycloak-operated](katalog/keycloak-operated)         | `26.2.2`                        | High availability KeyCloak using native Kubernetes namespace based discovery. This will form a KeyCloak cluster where the members will be all the KeyCloaks pods in the same Kubernetes namespace.                         |
 
 Click on each package to see its full documentation.
 

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,0 +1,31 @@
+# Keycloak Add-On Module Release 2.3.0
+
+Welcome to the latest release of `keycloak` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This is a patch release updating Keycloak Operator and Operated to v26.2.2 .
+
+## Component Images 🚢
+
+| Component               | Supported Version                                                                                   | Previous Version |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ---------------- |
+| `keycloak-operated`     | [`v26.2.2`](https://github.com/keycloak/keycloak/releases/tag/26.2.2)                               | `v26.0.2`      |
+| `keycloak-operator`     | [`v26.2.2`](https://github.com/keycloak/keycloak-k8s-resources/releases/tag/26.2.2)                 | `v26.0.2`      |
+
+## Bug Fixes and Changes 🐛
+
+- Updating Keycloak to v26.2.2
+
+- By default, the `--optimized` argument is now passed to the `kc.sh` command. To handle this behavior you can set the `spec.startOptimized` option in `Keycloak Custom Resource`.
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade this module from v2.2.0 to v2.3.0, execute the following:
+
+```bash
+
+
+```
+
+N.B. It's not required to upgrade the `keycloak-operated` package, since the Operator will take care of updating the pods.

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,6 +1,6 @@
 # Keycloak Add-On Module Release 2.3.0
 
-Welcome to the latest release of `keycloak` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP.
+Welcome to the latest release of `keycloak` add-on module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a minor release updating Keycloak Operator and Operated to v26.2.2 .
 

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -1,6 +1,6 @@
 # Keycloak Add-On Module Release 2.3.0
 
-Welcome to the latest release of `keycloak` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+Welcome to the latest release of `keycloak` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
 This is a patch release updating Keycloak Operator and Operated to v26.2.2 .
 
@@ -13,9 +13,9 @@ This is a patch release updating Keycloak Operator and Operated to v26.2.2 .
 
 ## Bug Fixes and Changes 🐛
 
-- Updating Keycloak to v26.2.2
+- Updating Keycloak Operator and Operated to v26.2.2 .
 
-- By default, the `--optimized` argument is now passed to the `kc.sh` command. To handle this behavior you can set the `spec.startOptimized` option in `Keycloak Custom Resource`.
+- By default, starting from the previous release, the `--optimized` argument is passed to the `kc.sh` command. To handle this behavior you can set the `spec.startOptimized` option in `Keycloak Custom Resource`.
 
 ## Update Guide 🦮
 
@@ -24,8 +24,32 @@ This is a patch release updating Keycloak Operator and Operated to v26.2.2 .
 To upgrade this module from v2.2.0 to v2.3.0, execute the following:
 
 ```bash
+KEYCLOAK_NS=<your_keycloak_namespace>
 
+# Remove the old Keycloak Operator. This will not delete Keycloak instances.
+kubectl delete deploy keycloak-operator -n $KEYCLOAK_NS
+
+# Update Keycloak Operator and CRDs
+kustomize build katalog/keycloak-operator | kubectl apply -n $KEYCLOAK_NS -f - 
 
 ```
 
 N.B. It's not required to upgrade the `keycloak-operated` package, since the Operator will take care of updating the pods.
+
+
+ℹ️ Known behaviour during upgrade
+
+During the first reconciliation loop after the upgrade to Keycloak Operator v26.2.2, something like this can be observed:
+
+```bash
+Error during event processing
+...
+The timeout period of 10000ms has been exceeded while executing PATCH
+...
+Conflict during reconciliation
+
+```
+
+The operator will recover and complete the reconciliation after a few seconds.
+
+No manual action is required.

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -13,7 +13,7 @@ This is a minor release updating Keycloak Operator and Operated to v26.2.2 .
 
 ## Bug Fixes and Changes 🐛
 
-- Updating Keycloak Operator and Operated to v26.2.2 .
+- Updated Keycloak Operator and Operated to v26.2.2 .
 
 - By default, starting from the previous release, the `--optimized` argument is passed to the `kc.sh` command. To handle this behavior you can set the `spec.startOptimized` option in `Keycloak Custom Resource`.
 

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -15,8 +15,6 @@ This is a minor release updating Keycloak Operator and Operated to v26.2.2 .
 
 - Updated Keycloak Operator and Operated to v26.2.2 .
 
-- By default, starting from the previous release, the `--optimized` argument is passed to the `kc.sh` command. To handle this behavior you can set the `spec.startOptimized` option in `Keycloak Custom Resource`.
-
 ## Update Guide 🦮
 
 ### Process

--- a/docs/releases/v2.3.0.md
+++ b/docs/releases/v2.3.0.md
@@ -2,7 +2,7 @@
 
 Welcome to the latest release of `keycloak` module of [`SIGHUP Distribution`](https://github.com/sighupio/distribution) maintained by team SIGHUP.
 
-This is a patch release updating Keycloak Operator and Operated to v26.2.2 .
+This is a minor release updating Keycloak Operator and Operated to v26.2.2 .
 
 ## Component Images 🚢
 

--- a/katalog/keycloak-operated/keycloak.yml
+++ b/katalog/keycloak-operated/keycloak.yml
@@ -8,7 +8,7 @@ kind: Keycloak
 metadata:
   name: keycloak
 spec:
-  image: registry.sighup.io/fury/keycloak/keycloak-spi-metrics:26.0.2
+  image: registry.sighup.io/fury/keycloak/keycloak-spi-metrics:26.2.2
   instances: 1
   http:
     httpEnabled: true

--- a/katalog/keycloak-operator/crds/keycloakrealmimports.k8s.keycloak.org-v1.yml
+++ b/katalog/keycloak-operator/crds/keycloakrealmimports.k8s.keycloak.org-v1.yml
@@ -64,6 +64,343 @@ spec:
                     type: "boolean"
                   adminEventsEnabled:
                     type: "boolean"
+                  adminPermissionsClient:
+                    properties:
+                      access:
+                        additionalProperties:
+                          type: "boolean"
+                        type: "object"
+                      adminUrl:
+                        type: "string"
+                      alwaysDisplayInConsole:
+                        type: "boolean"
+                      attributes:
+                        additionalProperties:
+                          type: "string"
+                        type: "object"
+                      authenticationFlowBindingOverrides:
+                        additionalProperties:
+                          type: "string"
+                        type: "object"
+                      authorizationServicesEnabled:
+                        type: "boolean"
+                      authorizationSettings:
+                        properties:
+                          allowRemoteResourceManagement:
+                            type: "boolean"
+                          authorizationSchema:
+                            properties:
+                              resourceTypes:
+                                additionalProperties:
+                                  properties:
+                                    groupType:
+                                      type: "string"
+                                    scopeAliases:
+                                      additionalProperties:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type: "object"
+                                    scopes:
+                                      items:
+                                        type: "string"
+                                      type: "array"
+                                    type:
+                                      type: "string"
+                                  type: "object"
+                                type: "object"
+                            type: "object"
+                          clientId:
+                            type: "string"
+                          decisionStrategy:
+                            enum:
+                            - "AFFIRMATIVE"
+                            - "CONSENSUS"
+                            - "UNANIMOUS"
+                            type: "string"
+                          id:
+                            type: "string"
+                          name:
+                            type: "string"
+                          policies:
+                            items:
+                              properties:
+                                config:
+                                  additionalProperties:
+                                    type: "string"
+                                  type: "object"
+                                decisionStrategy:
+                                  enum:
+                                  - "AFFIRMATIVE"
+                                  - "CONSENSUS"
+                                  - "UNANIMOUS"
+                                  type: "string"
+                                description:
+                                  type: "string"
+                                id:
+                                  type: "string"
+                                logic:
+                                  enum:
+                                  - "NEGATIVE"
+                                  - "POSITIVE"
+                                  type: "string"
+                                name:
+                                  type: "string"
+                                owner:
+                                  type: "string"
+                                policies:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                resourceType:
+                                  type: "string"
+                                resources:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                resourcesData:
+                                  items:
+                                    properties:
+                                      _id:
+                                        type: "string"
+                                      attributes:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      displayName:
+                                        type: "string"
+                                      icon_uri:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                      owner:
+                                        properties:
+                                          id:
+                                            type: "string"
+                                          name:
+                                            type: "string"
+                                        type: "object"
+                                      ownerManagedAccess:
+                                        type: "boolean"
+                                      scopes:
+                                        items:
+                                          properties:
+                                            displayName:
+                                              type: "string"
+                                            iconUri:
+                                              type: "string"
+                                            id:
+                                              type: "string"
+                                            name:
+                                              type: "string"
+                                          type: "object"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                      uris:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                    type: "object"
+                                  type: "array"
+                                scopes:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                                scopesData:
+                                  items:
+                                    properties:
+                                      displayName:
+                                        type: "string"
+                                      iconUri:
+                                        type: "string"
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                type:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                          policyEnforcementMode:
+                            enum:
+                            - "DISABLED"
+                            - "ENFORCING"
+                            - "PERMISSIVE"
+                            type: "string"
+                          resources:
+                            items:
+                              properties:
+                                _id:
+                                  type: "string"
+                                attributes:
+                                  additionalProperties:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                  type: "object"
+                                displayName:
+                                  type: "string"
+                                icon_uri:
+                                  type: "string"
+                                name:
+                                  type: "string"
+                                owner:
+                                  properties:
+                                    id:
+                                      type: "string"
+                                    name:
+                                      type: "string"
+                                  type: "object"
+                                ownerManagedAccess:
+                                  type: "boolean"
+                                scopes:
+                                  items:
+                                    properties:
+                                      displayName:
+                                        type: "string"
+                                      iconUri:
+                                        type: "string"
+                                      id:
+                                        type: "string"
+                                      name:
+                                        type: "string"
+                                    type: "object"
+                                  type: "array"
+                                type:
+                                  type: "string"
+                                uris:
+                                  items:
+                                    type: "string"
+                                  type: "array"
+                              type: "object"
+                            type: "array"
+                          scopes:
+                            items:
+                              properties:
+                                displayName:
+                                  type: "string"
+                                iconUri:
+                                  type: "string"
+                                id:
+                                  type: "string"
+                                name:
+                                  type: "string"
+                              type: "object"
+                            type: "array"
+                        type: "object"
+                      baseUrl:
+                        type: "string"
+                      bearerOnly:
+                        type: "boolean"
+                      clientAuthenticatorType:
+                        type: "string"
+                      clientId:
+                        type: "string"
+                      clientTemplate:
+                        type: "string"
+                      consentRequired:
+                        type: "boolean"
+                      defaultClientScopes:
+                        items:
+                          type: "string"
+                        type: "array"
+                      defaultRoles:
+                        items:
+                          type: "string"
+                        type: "array"
+                      description:
+                        type: "string"
+                      directAccessGrantsEnabled:
+                        type: "boolean"
+                      directGrantsOnly:
+                        type: "boolean"
+                      enabled:
+                        type: "boolean"
+                      frontchannelLogout:
+                        type: "boolean"
+                      fullScopeAllowed:
+                        type: "boolean"
+                      id:
+                        type: "string"
+                      implicitFlowEnabled:
+                        type: "boolean"
+                      name:
+                        type: "string"
+                      nodeReRegistrationTimeout:
+                        type: "integer"
+                      notBefore:
+                        type: "integer"
+                      optionalClientScopes:
+                        items:
+                          type: "string"
+                        type: "array"
+                      origin:
+                        type: "string"
+                      protocol:
+                        type: "string"
+                      protocolMappers:
+                        items:
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                            consentRequired:
+                              type: "boolean"
+                            consentText:
+                              type: "string"
+                            id:
+                              type: "string"
+                            name:
+                              type: "string"
+                            protocol:
+                              type: "string"
+                            protocolMapper:
+                              type: "string"
+                          type: "object"
+                        type: "array"
+                      publicClient:
+                        type: "boolean"
+                      redirectUris:
+                        items:
+                          type: "string"
+                        type: "array"
+                      registeredNodes:
+                        additionalProperties:
+                          type: "integer"
+                        type: "object"
+                      registrationAccessToken:
+                        type: "string"
+                      rootUrl:
+                        type: "string"
+                      secret:
+                        type: "string"
+                      serviceAccountsEnabled:
+                        type: "boolean"
+                      standardFlowEnabled:
+                        type: "boolean"
+                      surrogateAuthRequired:
+                        type: "boolean"
+                      type:
+                        type: "string"
+                      useTemplateConfig:
+                        type: "boolean"
+                      useTemplateMappers:
+                        type: "boolean"
+                      useTemplateScope:
+                        type: "boolean"
+                      webOrigins:
+                        items:
+                          type: "string"
+                        type: "array"
+                    type: "object"
+                  adminPermissionsEnabled:
+                    type: "boolean"
                   adminTheme:
                     type: "string"
                   applicationScopeMappings:
@@ -110,6 +447,28 @@ spec:
                           properties:
                             allowRemoteResourceManagement:
                               type: "boolean"
+                            authorizationSchema:
+                              properties:
+                                resourceTypes:
+                                  additionalProperties:
+                                    properties:
+                                      groupType:
+                                        type: "string"
+                                      scopeAliases:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      scopes:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                    type: "object"
+                                  type: "object"
+                              type: "object"
                             clientId:
                               type: "string"
                             decisionStrategy:
@@ -152,6 +511,8 @@ spec:
                                     items:
                                       type: "string"
                                     type: "array"
+                                  resourceType:
+                                    type: "string"
                                   resources:
                                     items:
                                       type: "string"
@@ -484,6 +845,11 @@ spec:
                     type: "object"
                   bruteForceProtected:
                     type: "boolean"
+                  bruteForceStrategy:
+                    enum:
+                    - "LINEAR"
+                    - "MULTIPLE"
+                    type: "string"
                   certificate:
                     type: "string"
                   clientAuthenticationFlow:
@@ -638,6 +1004,28 @@ spec:
                           properties:
                             allowRemoteResourceManagement:
                               type: "boolean"
+                            authorizationSchema:
+                              properties:
+                                resourceTypes:
+                                  additionalProperties:
+                                    properties:
+                                      groupType:
+                                        type: "string"
+                                      scopeAliases:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      scopes:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                    type: "object"
+                                  type: "object"
+                              type: "object"
                             clientId:
                               type: "string"
                             decisionStrategy:
@@ -680,6 +1068,8 @@ spec:
                                     items:
                                       type: "string"
                                     type: "array"
+                                  resourceType:
+                                    type: "string"
                                   resources:
                                     items:
                                       type: "string"
@@ -1318,6 +1708,8 @@ spec:
                                 type: "string"
                               digits:
                                 type: "integer"
+                              federationLink:
+                                type: "string"
                               hashIterations:
                                 type: "integer"
                               hashedSaltedValue:
@@ -1951,6 +2343,28 @@ spec:
                           properties:
                             allowRemoteResourceManagement:
                               type: "boolean"
+                            authorizationSchema:
+                              properties:
+                                resourceTypes:
+                                  additionalProperties:
+                                    properties:
+                                      groupType:
+                                        type: "string"
+                                      scopeAliases:
+                                        additionalProperties:
+                                          items:
+                                            type: "string"
+                                          type: "array"
+                                        type: "object"
+                                      scopes:
+                                        items:
+                                          type: "string"
+                                        type: "array"
+                                      type:
+                                        type: "string"
+                                    type: "object"
+                                  type: "object"
+                              type: "object"
                             clientId:
                               type: "string"
                             decisionStrategy:
@@ -1993,6 +2407,8 @@ spec:
                                     items:
                                       type: "string"
                                     type: "array"
+                                  resourceType:
+                                    type: "string"
                                   resources:
                                     items:
                                       type: "string"
@@ -2400,6 +2816,8 @@ spec:
                                       type: "string"
                                     digits:
                                       type: "integer"
+                                    federationLink:
+                                      type: "string"
                                     hashIterations:
                                       type: "integer"
                                     hashedSaltedValue:
@@ -2933,6 +3351,8 @@ spec:
                                 type: "string"
                               digits:
                                 type: "integer"
+                              federationLink:
+                                type: "string"
                               hashIterations:
                                 type: "integer"
                               hashedSaltedValue:
@@ -3068,6 +3488,8 @@ spec:
                           type: "string"
                       type: "object"
                     type: "array"
+                  verifiableCredentialsEnabled:
+                    type: "boolean"
                   verifyEmail:
                     type: "boolean"
                   waitIncrementSeconds:
@@ -3137,6 +3559,8 @@ spec:
                     items:
                       properties:
                         name:
+                          type: "string"
+                        request:
                           type: "string"
                       type: "object"
                     type: "array"

--- a/katalog/keycloak-operator/crds/keycloaks.k8s.keycloak.org-v1.yml
+++ b/katalog/keycloak-operator/crds/keycloaks.k8s.keycloak.org-v1.yml
@@ -244,6 +244,197 @@ spec:
               instances:
                 description: "Number of Keycloak instances. Default is 1."
                 type: "integer"
+              networkPolicy:
+                description: "Controls the ingress traffic flow into Keycloak pods."
+                properties:
+                  enabled:
+                    default: true
+                    description: "Enables or disables the ingress traffic control."
+                    type: "boolean"
+                  http:
+                    description: "A list of sources which should be able to access\
+                      \ this endpoint. Items in this list are combined using a logical\
+                      \ OR operation. If this field is empty or missing, this rule\
+                      \ matches all sources (traffic not restricted by source). If\
+                      \ this field is present and contains at least one item, this\
+                      \ rule allows traffic only if the traffic matches at least one\
+                      \ item in the from list."
+                    items:
+                      properties:
+                        ipBlock:
+                          properties:
+                            cidr:
+                              type: "string"
+                            except:
+                              items:
+                                type: "string"
+                              type: "array"
+                          type: "object"
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                      type: "object"
+                    type: "array"
+                  https:
+                    description: "A list of sources which should be able to access\
+                      \ this endpoint. Items in this list are combined using a logical\
+                      \ OR operation. If this field is empty or missing, this rule\
+                      \ matches all sources (traffic not restricted by source). If\
+                      \ this field is present and contains at least one item, this\
+                      \ rule allows traffic only if the traffic matches at least one\
+                      \ item in the from list."
+                    items:
+                      properties:
+                        ipBlock:
+                          properties:
+                            cidr:
+                              type: "string"
+                            except:
+                              items:
+                                type: "string"
+                              type: "array"
+                          type: "object"
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                      type: "object"
+                    type: "array"
+                  management:
+                    description: "A list of sources which should be able to access\
+                      \ this endpoint. Items in this list are combined using a logical\
+                      \ OR operation. If this field is empty or missing, this rule\
+                      \ matches all sources (traffic not restricted by source). If\
+                      \ this field is present and contains at least one item, this\
+                      \ rule allows traffic only if the traffic matches at least one\
+                      \ item in the from list."
+                    items:
+                      properties:
+                        ipBlock:
+                          properties:
+                            cidr:
+                              type: "string"
+                            except:
+                              items:
+                                type: "string"
+                              type: "array"
+                          type: "object"
+                        namespaceSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                        podSelector:
+                          properties:
+                            matchExpressions:
+                              items:
+                                properties:
+                                  key:
+                                    type: "string"
+                                  operator:
+                                    type: "string"
+                                  values:
+                                    items:
+                                      type: "string"
+                                    type: "array"
+                                type: "object"
+                              type: "array"
+                            matchLabels:
+                              additionalProperties:
+                                type: "string"
+                              type: "object"
+                          type: "object"
+                      type: "object"
+                    type: "array"
+                type: "object"
               proxy:
                 description: "In this section you can configure Keycloak's reverse\
                   \ proxy setting"
@@ -261,6 +452,8 @@ spec:
                     items:
                       properties:
                         name:
+                          type: "string"
+                        request:
                           type: "string"
                       type: "object"
                     type: "array"
@@ -674,6 +867,45 @@ spec:
                   \ the start command. If left unspecified the operator will assume\
                   \ custom images have already been augmented."
                 type: "boolean"
+              tracing:
+                description: "In this section you can configure OpenTelemetry Tracing\
+                  \ for Keycloak."
+                properties:
+                  compression:
+                    description: "OpenTelemetry compression method used to compress\
+                      \ payloads. If unset, compression is disabled. Possible values\
+                      \ are: gzip, none."
+                    type: "string"
+                  enabled:
+                    description: "Enables the OpenTelemetry tracing."
+                    type: "boolean"
+                  endpoint:
+                    description: "OpenTelemetry endpoint to connect to."
+                    type: "string"
+                  protocol:
+                    description: "OpenTelemetry protocol used for the telemetry data\
+                      \ (default 'grpc'). For more information, check the Tracing\
+                      \ guide."
+                    type: "string"
+                  resourceAttributes:
+                    additionalProperties:
+                      type: "string"
+                    description: "OpenTelemetry resource attributes present in the\
+                      \ exported trace to characterize the telemetry producer."
+                    type: "object"
+                  samplerRatio:
+                    description: "OpenTelemetry sampler ratio. Probability that a\
+                      \ span will be sampled. Expected double value in interval [0,1]."
+                    type: "number"
+                  samplerType:
+                    description: "OpenTelemetry sampler to use for tracing (default\
+                      \ 'traceidratio'). For more information, check the Tracing guide."
+                    type: "string"
+                  serviceName:
+                    description: "OpenTelemetry service name. Takes precedence over\
+                      \ 'service.name' defined in the 'resourceAttributes' map."
+                    type: "string"
+                type: "object"
               transaction:
                 description: "In this section you can find all properties related\
                   \ to the settings of transaction behavior."
@@ -1460,6 +1692,8 @@ spec:
                                         properties:
                                           name:
                                             type: "string"
+                                          request:
+                                            type: "string"
                                         type: "object"
                                       type: "array"
                                     limits:
@@ -2011,6 +2245,8 @@ spec:
                                       items:
                                         properties:
                                           name:
+                                            type: "string"
+                                          request:
                                             type: "string"
                                         type: "object"
                                       type: "array"
@@ -2570,6 +2806,8 @@ spec:
                                         properties:
                                           name:
                                             type: "string"
+                                          request:
+                                            type: "string"
                                         type: "object"
                                       type: "array"
                                     limits:
@@ -2793,15 +3031,38 @@ spec:
                               properties:
                                 name:
                                   type: "string"
-                                source:
-                                  properties:
-                                    resourceClaimName:
-                                      type: "string"
-                                    resourceClaimTemplateName:
-                                      type: "string"
-                                  type: "object"
+                                resourceClaimName:
+                                  type: "string"
+                                resourceClaimTemplateName:
+                                  type: "string"
                               type: "object"
                             type: "array"
+                          resources:
+                            properties:
+                              claims:
+                                items:
+                                  properties:
+                                    name:
+                                      type: "string"
+                                    request:
+                                      type: "string"
+                                  type: "object"
+                                type: "array"
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: "integer"
+                                  - type: "string"
+                                  x-kubernetes-int-or-string: true
+                                type: "object"
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: "integer"
+                                  - type: "string"
+                                  x-kubernetes-int-or-string: true
+                                type: "object"
+                            type: "object"
                           restartPolicy:
                             type: "string"
                           runtimeClassName:
@@ -2834,6 +3095,8 @@ spec:
                                 type: "boolean"
                               runAsUser:
                                 type: "integer"
+                              seLinuxChangePolicy:
+                                type: "string"
                               seLinuxOptions:
                                 properties:
                                   level:
@@ -2856,6 +3119,8 @@ spec:
                                 items:
                                   type: "integer"
                                 type: "array"
+                              supplementalGroupsPolicy:
+                                type: "string"
                               sysctls:
                                 items:
                                   properties:
@@ -3325,6 +3590,13 @@ spec:
                                     type:
                                       type: "string"
                                   type: "object"
+                                image:
+                                  properties:
+                                    pullPolicy:
+                                      type: "string"
+                                    reference:
+                                      type: "string"
+                                  type: "object"
                                 iscsi:
                                   properties:
                                     chapAuthDiscovery:
@@ -3623,6 +3895,26 @@ spec:
                         type: "object"
                     type: "object"
                 type: "object"
+              update:
+                description: "Configuration related to Keycloak deployment updates."
+                properties:
+                  revision:
+                    description: "When use the Explicit strategy, the revision signals\
+                      \ if a rolling update can be used or not."
+                    type: "string"
+                  strategy:
+                    default: "RecreateOnImageChange"
+                    description: "Sets the update strategy to use."
+                    enum:
+                    - "Auto"
+                    - "Explicit"
+                    - "RecreateOnImageChange"
+                    type: "string"
+                type: "object"
+                x-kubernetes-validations:
+                - message: "The 'revision' field is required when 'Explicit' strategy\
+                    \ is used"
+                  rule: "self.strategy != 'Explicit' || has(self.revision)"
             type: "object"
           status:
             properties:

--- a/katalog/keycloak-operator/keycloak-operator.yml
+++ b/katalog/keycloak-operator/keycloak-operator.yml
@@ -7,12 +7,12 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.15.1
+    app.quarkus.io/quarkus-version: 3.20.0
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2024-10-24 - 08:01:08 +0000
+    app.quarkus.io/build-timestamp: 2025-04-30 - 06:21:03 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.0.2
+    app.kubernetes.io/version: 26.2.2
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 ---
@@ -31,6 +31,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/name: keycloak-operator
+    app.kubernetes.io/version: 26.2.2
   name: keycloakrealmimportcontroller-cluster-role
 rules:
   - apiGroups:
@@ -48,6 +51,17 @@ rules:
       - create
       - delete
   - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+  - apiGroups:
       - ""
     resources:
       - secrets
@@ -63,6 +77,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/name: keycloak-operator
+    app.kubernetes.io/version: 26.2.2
   name: keycloakcontroller-cluster-role
 rules:
   - apiGroups:
@@ -92,6 +109,18 @@ rules:
       - update
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
       - networking.k8s.io
     resources:
       - ingresses
@@ -112,6 +141,18 @@ rules:
       - delete
       - get
       - list
+      - watch
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -215,6 +256,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/name: keycloak-operator
+    app.kubernetes.io/version: 26.2.2
   name: keycloakrealmimportcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -227,6 +271,9 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/name: keycloak-operator
+    app.kubernetes.io/version: 26.2.2
   name: keycloakcontroller-role-binding
 roleRef:
   kind: ClusterRole
@@ -241,7 +288,7 @@ kind: RoleBinding
 metadata:
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.0.2
+    app.kubernetes.io/version: 26.2.2
   name: keycloak-operator-view
 roleRef:
   kind: ClusterRole
@@ -255,12 +302,12 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.15.1
+    app.quarkus.io/quarkus-version: 3.20.0
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2024-10-24 - 08:01:08 +0000
+    app.quarkus.io/build-timestamp: 2025-04-30 - 06:21:03 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.0.2
+    app.kubernetes.io/version: 26.2.2
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -277,12 +324,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
-    app.quarkus.io/quarkus-version: 3.15.1
+    app.quarkus.io/quarkus-version: 3.20.0
     app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-    app.quarkus.io/build-timestamp: 2024-10-24 - 08:01:08 +0000
+    app.quarkus.io/build-timestamp: 2025-04-30 - 06:21:03 +0000
   labels:
     app.kubernetes.io/name: keycloak-operator
-    app.kubernetes.io/version: 26.0.2
+    app.kubernetes.io/version: 26.2.2
     app.kubernetes.io/managed-by: quarkus
   name: keycloak-operator
 spec:
@@ -293,12 +340,12 @@ spec:
   template:
     metadata:
       annotations:
-        app.quarkus.io/quarkus-version: 3.15.1
+        app.quarkus.io/quarkus-version: 3.20.0
         app.quarkus.io/vcs-uri: https://github.com/keycloak/keycloak.git
-        app.quarkus.io/build-timestamp: 2024-10-24 - 08:01:08 +0000
+        app.quarkus.io/build-timestamp: 2025-04-30 - 06:21:03 +0000
       labels:
         app.kubernetes.io/managed-by: quarkus
-        app.kubernetes.io/version: 26.0.2
+        app.kubernetes.io/version: 26.2.2
         app.kubernetes.io/name: keycloak-operator
     spec:
       containers:
@@ -308,8 +355,8 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: RELATED_IMAGE_KEYCLOAK
-              value: quay.io/keycloak/keycloak:26.0.2
-          image: quay.io/keycloak/keycloak-operator:26.0.2
+              value: quay.io/keycloak/keycloak:26.2.2
+          image: quay.io/keycloak/keycloak-operator:26.2.2
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3

--- a/katalog/keycloak-operator/patches/keycloak-image.yml
+++ b/katalog/keycloak-operator/patches/keycloak-image.yml
@@ -14,4 +14,4 @@ spec:
         - name: keycloak-operator
           env:
             - name: RELATED_IMAGE_KEYCLOAK
-              value: registry.sighup.io/fury/keycloak/keycloak-spi-metrics:26.0.2
+              value: registry.sighup.io/fury/keycloak/keycloak-spi-metrics:26.2.2


### PR DESCRIPTION
### Summary 💡

This PR upgrades Keycloak Operator from `v26.0.2` to `v26.2.2`.

Closes: [sighupio/product-management/issues/598](https://github.com/sighupio/product-management/issues/598)

### Description 📝
 
It includes version bumps of Quarkus and Operator SDK dependencies.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] Upgraded from `v2.2.0` to `v2.3.0`
- [x] Tested the new deployment with Kind 1.32

### Future work 🔧

None.
